### PR TITLE
Preserve returns in generated helpers

### DIFF
--- a/src/PolyBranch.jl
+++ b/src/PolyBranch.jl
@@ -108,7 +108,12 @@ function transform(ir)
         branches = IRTools.branches(header) 
         for i=length(branches_rev):-1:1
             br = branches_rev[i]
-            br2 = Branch(lookup(br.condition), br.block+1, map(lookup, br.args))
+            br2 = if IRTools.isreturn(br)
+                # Destination block should stay 0 for returns
+                Branch(nothing, 0, map(lookup, br.args))
+            else
+                Branch(lookup(br.condition), br.block+1, map(lookup, br.args))
+            end
             push!(branches, br2)
         end
         sym, help_ir

--- a/test/weighted_average_tests.jl
+++ b/test/weighted_average_tests.jl
@@ -35,6 +35,26 @@ IfElse.ifelse(guard::AbstractFloat, then, elze) = guard*then + (1-guard)*elze
 
 end
 
+@testset "weighted average if-then-zero-else-seven" begin
+    function zero_or_seven(cond)
+        if cond
+            0
+        else
+            7
+        end
+    end
+    zero_or_seven2 = gen_polybr_f(typeof(zero_or_seven), Any)
+
+    # `Bool` guards still work
+    @test zero_or_seven2(true) ≈ 0
+    @test zero_or_seven2(false) ≈ 7
+
+    # `AbstractFloat`` guards now also work
+    @test zero_or_seven2(1.) ≈ 0
+    @test zero_or_seven2(0.) ≈ 7
+    @test zero_or_seven2(0.4) ≈ 0.6 * 7
+end
+
 @testset "weighted average while" begin
     
     # expected number of `true` sampled coins at start of list


### PR DESCRIPTION
In generated helper IRs, branches to block X are transformed to branches to block X+1, to account for a new header block. However, returns should always point to the "psuedo-block" 0.

Also added a test to verify this fix.

**PR stack:**
1) [**#4 Preserve returns in generated helpers**](https://github.com/Juice-jl/PolyBranch.jl/pull/4)
2) [#5 Ensure blocks are fully functional by preventing fallthrough](https://github.com/Juice-jl/PolyBranch.jl/pull/5)